### PR TITLE
Support machine v15

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -263,7 +263,7 @@ module.exports = {
     WET_MACHINES.createManager({
       connectionString: dsConfig.url,
       meta: _.omit(dsConfig, ['adapter', 'url', 'identity', 'schema'])
-    }, {
+    }).switch({
       error: function(err) {
         return done(new Error('Consistency violation: Unexpected error creating db connection manager:\n```\n'+err.stack+'\n```'));
       },
@@ -397,7 +397,7 @@ module.exports = {
     //   ║║║╣ ╚═╗ ║ ╠╦╝║ ║╚╦╝  │││├─┤│││├─┤│ ┬├┤ ├┬┘
     //  ═╩╝╚═╝╚═╝ ╩ ╩╚═╚═╝ ╩   ┴ ┴┴ ┴┘└┘┴ ┴└─┘└─┘┴└─
     // Destroy the manager.
-    WET_MACHINES.destroyManager({ manager: dsEntry.manager }, {
+    WET_MACHINES.destroyManager({ manager: dsEntry.manager }).switch({
       error: function(err) { return done(new Error('Encountered unexpected error when attempting to destroy the connection manager.\n\n```\n'+err.stack+'\n```')); },
       failed: function(report) {
         var err = new Error('Datastore (`'+datastoreName+'`) could not be torn down because of a failure when attempting to destroy the connection manager.\n\n```\n'+report.error.stack+'\n```');

--- a/lib/private/build-std-adapter-method.js
+++ b/lib/private/build-std-adapter-method.js
@@ -62,7 +62,7 @@ module.exports = function buildStdAdapterMethod (machineDef, WET_MACHINES, regis
         };
         // If this machine has a `notUnique` exit, then set up a `notUnique` handler.
         // > (Note that `err.footprint` should already be attached, so there's no need to mess w/ it.)
-        if (performQuery.exits.notUnique) {
+        if (machineDef.exits.notUnique) {
           handlers.notUnique = function (err) { return proceed(err); };
         }
 

--- a/lib/private/build-std-adapter-method.js
+++ b/lib/private/build-std-adapter-method.js
@@ -71,7 +71,7 @@ module.exports = function buildStdAdapterMethod (machineDef, WET_MACHINES, regis
           query: s3q,
           connection: connection,
           dryOrm: { models: registeredDryModels }
-        }).exec(handlers);
+        }).switch(handlers);
 
       }//</:during>
     }, done);//</doWithConnection()>

--- a/lib/private/do-with-connection.js
+++ b/lib/private/do-with-connection.js
@@ -80,7 +80,7 @@ module.exports = function doWithConnection(options, done){
     options.WET_MACHINES.getConnection({
       manager: options.manager,
       meta: options.meta
-    }, {
+    }).switch({
       error: function (err){ return proceed(err); },
       failed: function (report){
         if (report.meta) { report.error.meta = report.meta; }
@@ -180,7 +180,7 @@ module.exports = function doWithConnection(options, done){
         // > -@mikermcneil
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-        options.WET_MACHINES.releaseConnection({ connection: db, meta: options.meta }, {
+        options.WET_MACHINES.releaseConnection({ connection: db, meta: options.meta }).switch({
           error: function(secondaryErr) {
             // This is a rare case, but still, if it happens, we make sure to tell
             // the calling code _exactly_ what occurred.
@@ -239,7 +239,7 @@ module.exports = function doWithConnection(options, done){
         return done(undefined, resultMaybe);
       }//-•
 
-      options.WET_MACHINES.releaseConnection({ connection: db, meta: options.meta }, {
+      options.WET_MACHINES.releaseConnection({ connection: db, meta: options.meta }).switch({
         error: function(secondaryErr) {
           return done(new Error(
             'The code in the provided `during` function ran successfully with this\n'+

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "1.1.1",
-    "machine": "^13.0.0-17",
+    "machine": "^15.0.0",
     "mongodb": "2.2.25",
     "qs": "6.4.0"
   },


### PR DESCRIPTION
This simple little PR has `sails-mongo` basically working with [machine](https://github.com/node-machine/machine) v15.

All tests are passing, and a cursory run-through of different use-cases in our Sails apps show things to be functioning properly, at least.

The inspiration for switching to machine v15 is on the bug-fix front... Specifically, a rather troublesome memory-leak present in v13 is no more!

Without these patches up to v15 at least, it was necessary to remove `Debug()` calls from the v13 machine in order to achieve acceptable memory usage and avoid performance degradation. When the calls to `Debug()` remain, the result is an endlessly growing list of debug objects, sneakily hiding away from the GC, and that's no bueno.

**Disclaimer:** I'm not intimately familiar with the [machine](https://github.com/node-machine/machine) internals... at all. The same can be said for my knowledge of Sails adapters. I've only really spent the basic effort to peek through a heap snapshot, isolate the leak, (hackily) fix it on v13... discover it's not present in v15, up the version, and get things to stop erroring out. So while things work great here, the same can't be said for every project!